### PR TITLE
CODEOWNERS: improve code ownership coverage

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 * @serve-robotics/mapping
+
+.github/workflows/security*     @serve-robotics/security
+CODEOWNERS                      @serve-robotics/security
+SEC-SCS                         @serve-robotics/security


### PR DESCRIPTION
This PR adds mandatory security team ownership entries to the CODEOWNERS file.

Changes:
- Adds `.github/workflows/security*` owned by `@serve-robotics/security`
- Adds `CODEOWNERS` owned by `@serve-robotics/security`
- Adds `SEC-SCS` owned by `@serve-robotics/security`
- Existing `* @serve-robotics/mapping` catch-all is preserved

Generated with Claude Code